### PR TITLE
Configurable ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ $ vagrant destroy
 $ vagrant up
 ```
 
+### Adding or changing the forwarded ports
+
+When a site is started, it requires 3 forwarded ports for the Solidus server, the log server and LiveReload. By default, 45 ports are forwarded when the box is started. Once a site has been started, its used ports will be reserved for later use. If you run out of ports, or if a default port is already used by another application on your machine, you can manage them directly in the Vagrantfile, with the following config variables, which should be arrays of available ports. Note that the box should be reloaded if those values are changed.
+
+* `config.solidus.site_ports`
+* `config.solidus.livereload_ports`
+* `config.solidus.log_server_ports`
+
+It's also possible to remove ports reserved by older unused sites. The reserved ports are listed in this file: `.vagrant-solidus/data/sites.json`.
+
 [virtualbox]: https://www.virtualbox.org
 [virtualbox-install]: https://www.virtualbox.org/wiki/Downloads
 [vagrant]: http://www.vagrantup.com

--- a/lib/vagrant-solidus.rb
+++ b/lib/vagrant-solidus.rb
@@ -7,6 +7,11 @@ module VagrantPlugins
       name 'Solidus'
       description 'This plugin provides a provisioner and a `site` command that allows Solidus sites to be managed by Vagrant.'
 
+      config(:solidus) do
+        require_relative 'vagrant-solidus/config'
+        Config
+      end
+
       provisioner(:solidus) do
         require_relative 'vagrant-solidus/provisioner'
         Provisioner

--- a/lib/vagrant-solidus/config.rb
+++ b/lib/vagrant-solidus/config.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module Solidus
+    class Config < Vagrant.plugin('2', :config)
+      attr_accessor :site_ports, :livereload_ports, :log_server_ports
+
+      def initialize
+        @site_ports       = (8081..8095).to_a
+        @livereload_ports = (35730..35744).to_a
+        @log_server_ports = (35745..35759).to_a
+      end
+    end
+  end
+end

--- a/lib/vagrant-solidus/provisioner.rb
+++ b/lib/vagrant-solidus/provisioner.rb
@@ -4,15 +4,8 @@ module VagrantPlugins
       include VagrantPlugins::Solidus::SiteHelpers
 
       def configure(root_config)
-        # TODO: Make this configurable
-        15.times do |i|
-          port = VagrantPlugins::Solidus::SiteHelpers::BASE_PORT + i
+        (root_config.solidus.site_ports + root_config.solidus.livereload_ports + root_config.solidus.log_server_ports).each do |port|
           root_config.vm.network :forwarded_port, guest: port, host: port
-
-          2.times do |j|
-            port = VagrantPlugins::Solidus::SiteHelpers::BASE_UTILS_PORT + (2 * i) + j
-            root_config.vm.network :forwarded_port, guest: port, host: port
-          end
         end
       end
 

--- a/lib/vagrant-solidus/site/start.rb
+++ b/lib/vagrant-solidus/site/start.rb
@@ -16,11 +16,13 @@ module VagrantPlugins
           with_running_vm do
             stop_site
 
+            @env.ui.info("Installing site...")
             unless @fast
-              @env.ui.info("Installing site...")
-              fail("Site could not be installed") unless install_site
-              install_pow_site if pow_installed?
+              fail("Site could not be installed") unless install_site_dependencies && install_site_node_packages
             end
+            fail("Out of available ports, add more to the Vagrantfile or remove unused sites from #{SITES_CONFIGS_FILE_HOST_PATH}") unless set_site_ports
+            fail("Site could not be installed") unless install_site_service
+            install_pow_site if pow_installed?
 
             @env.ui.info("Starting dev server...")
             fail("Site could not be started") unless start_site_service
@@ -39,12 +41,6 @@ module VagrantPlugins
 
           # Success, exit status 0
           0
-        end
-
-        private
-
-        def install_site
-          install_site_dependencies && install_site_node_packages && install_site_service
         end
       end
     end

--- a/lib/vagrant-solidus/solidus-box/Vagrantfile
+++ b/lib/vagrant-solidus/solidus-box/Vagrantfile
@@ -27,4 +27,13 @@ Vagrant.configure('2') do |config|
   # The vagrant-solidus plugin handles the rest, see:
   #   https://github.com/solidusjs/vagrant-solidus
   config.vm.provision :solidus
+
+  # List of available ports for the Solidus sites, reload the box if you change this
+  #config.solidus.site_ports = [...]
+
+  # List of available ports for LiveReload, reload the box if you change this
+  #config.solidus.livereload_ports = [...]
+
+  # List of available ports for the Solidus log servers, reload the box if you change this
+  #config.solidus.log_server_ports = [...]
 end


### PR DESCRIPTION
Fixes #2

Forwarded ports can be configured through the Vagrantfile, with the following variables (they must contain arrays of integers):
- `config.solidus.site_ports`
- `config.solidus.livereload_ports`
- `config.solidus.log_server_ports`
