### PR TITLE
Use site's node and npm versions from package.json

### DIFF
--- a/lib/vagrant-solidus/provisioner.rb
+++ b/lib/vagrant-solidus/provisioner.rb
@@ -32,12 +32,18 @@ module VagrantPlugins
         @env.ui.info('Installing dos2unix')
         execute('apt-get -y install dos2unix', sudo: true)
 
-        @env.ui.info('Installing nvm, node.js and npm')
-        execute('curl -s https://raw.githubusercontent.com/creationix/nvm/v0.5.1/install.sh | sh')
+        @env.ui.info('Installing nvm')
+        execute('curl -s https://raw.githubusercontent.com/creationix/nvm/v0.25.1/install.sh | sh')
         execute('source ~/.nvm/nvm.sh')
-        execute('nvm install 0.10.22')
-        execute('nvm use 0.10.22')
-        execute('nvm alias default 0.10.22')
+
+        # Install a default node.js version, it will be used for grunt-init and when ssh'ing into the box
+        @env.ui.info('Installing node.js')
+        execute("nvm install #{DEFAULT_NODE_VERSION}")
+        execute("nvm use #{DEFAULT_NODE_VERSION}")
+        execute("nvm alias default #{DEFAULT_NODE_VERSION}")
+
+        @env.ui.info('Installing npm')
+        execute("npm install npm@'#{DEFAULT_NPM_VERSION}' -g")
 
         @env.ui.info('Installing grunt-init')
         execute('npm install grunt-init@"~0.3.1" -g')

--- a/lib/vagrant-solidus/site/run.rb
+++ b/lib/vagrant-solidus/site/run.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
 
         def execute
           with_running_vm do
-            guest_exec(:log_all, "cd #{@site_guest_path} && #{@guest_command}")
+            guest_exec(:log_all, "cd #{@site_guest_path} && #{node_command} #{@guest_command}")
           end
 
           # Command's exit status

--- a/lib/vagrant-solidus/site/start.rb
+++ b/lib/vagrant-solidus/site/start.rb
@@ -18,9 +18,9 @@ module VagrantPlugins
 
             @env.ui.info("Installing site...")
             unless @fast
-              fail("Site could not be installed") unless install_site_dependencies && install_site_node_packages
+              fail("Site could not be installed") unless install_site_dependencies && install_site_node && install_site_node_packages
             end
-            fail("Out of available ports, add more to the Vagrantfile or remove unused sites from #{SITES_CONFIGS_FILE_HOST_PATH}") unless set_site_ports
+            fail("Out of available ports, add more to the Vagrantfile or remove unused sites from #{SITES_CONFIGS_FILE_HOST_PATH}\nSee https://github.com/solidusjs/vagrant-solidus#adding-or-changing-the-forwarded-ports") unless set_site_ports
             fail("Site could not be installed") unless install_site_service
             install_pow_site if pow_installed?
 


### PR DESCRIPTION
If missing, the default node version is `stable` and the default npm version is `^2.0.0`.

Whenever a node command is run, it is now automatically prefixed with `nvm exec [site node version]`.

When provisioning, the default versions are installed, to be used with the grunt-init commands and when ssh'ing into the box.